### PR TITLE
Add /skyline as command

### DIFF
--- a/SMT/core/gui.lua
+++ b/SMT/core/gui.lua
@@ -908,6 +908,7 @@ options.CD_Icons_alpha.apply = function() T.EditCDBar("alpha") end
 ----------------------------------------------------------
 
 SLASH_SMT1 = "/smt"
+SLASH_SMT2 = "/skyline"
 SlashCmdList["SMT"] = function(arg)
 	if gui:IsShown() then
 		gui:Hide()


### PR DESCRIPTION
Hey there !

Regarding the issue with a french game #1 :
It looks like `/smt` is a command already defined by Blizzard, thus the one from your addon doesn't trigger as it should.
I've added `/skyline` to avoid using /smt for french player (and maybe other locale) :)

Thanks for sharing this addon ! :)