### PR TITLE
 Allow SMT to function with ElvUI party frames

### DIFF
--- a/SMT/core/cd_icons.lua
+++ b/SMT/core/cd_icons.lua
@@ -189,14 +189,14 @@ local function CreateCDBar(unit)
 			local hasGrid2 = IsAddOnLoaded("Grid2")
 			local hasCompactRaid = IsAddOnLoaded("CompactRaid")
 			local hasVuhDo = IsAddOnLoaded("VuhDo")
-			local hasElvUI = _G["ElvUF_Raid"] and _G["ElvUF_Raid"]:IsVisible()
+			local hasElvUI = _G["ElvUF_Party"] and _G["ElvUF_Party"]:IsVisible()
 			local hasAltzUI = _G["Altz_HealerRaid"] and _G["Altz_HealerRaid"]:IsVisible()
 			local hasNDui = IsAddOnLoaded("NDui")
 			
 			if hasElvUI then
 				for i=1, 8 do
 					for j=1, 5 do
-						local uf = _G["ElvUF_RaidGroup"..i.."UnitButton"..j]
+						local uf = _G["ElvUF_PartyGroup"..i.."UnitButton"..j]
 						if uf and uf.unit and UnitIsUnit(uf.unit, unit) then
 							if SMT_CDB["CD_Icons"]["grow_dir"] == "RIGHT" then
 								f:SetPoint("RIGHT", uf, "LEFT", -SMT_CDB["CD_Icons"]["x"], SMT_CDB["CD_Icons"]["y"])

--- a/SMT/core/core.lua
+++ b/SMT/core/core.lua
@@ -1683,14 +1683,14 @@ T.HL_OnRaid = function(v, t, target, sourceGUID)
     local hasGrid2 = IsAddOnLoaded("Grid2")
     local hasCompactRaid = IsAddOnLoaded("CompactRaid")
     local hasVuhDo = IsAddOnLoaded("VuhDo")
-    local hasElvUI = _G["ElvUF_Raid"] and _G["ElvUF_Raid"]:IsVisible()
+    local hasElvUI = _G["ElvUF_Party"] and _G["ElvUF_Party"]:IsVisible()
     local hasAltzUI = _G["Altz_HealerRaid"] and _G["Altz_HealerRaid"]:IsVisible()
     local hasNDui = IsAddOnLoaded("NDui")
 	
     if hasElvUI then
         for i=1, 8 do
             for j=1, 5 do
-                local f = _G["ElvUF_RaidGroup"..i.."UnitButton"..j]
+                local f = _G["ElvUF_PartyGroup"..i.."UnitButton"..j]
                 if f and f.unit and UnitName(f.unit) == target then
                     add_Icon(f, v, t, target, sourceGUID)
                     return


### PR DESCRIPTION
The most common group-display setup for people using ElvUI frames in dungeons is ElvUI's built-in party frames, not the raid frames.

This makes it so that SMT's features can anchor to those frames instead of trying to anchor to the usually-non-existent ElvUI raid frames.

Forgive me if this isn't completely correct as I'm rather inexperienced with addon development, but testing this locally worked fine for me as an ElvUI user.

Sorry about the linebreaks at the end of the files, too. GitHub's editor made that change on its own.